### PR TITLE
Rewrite main.js:format to enforce return type + prevent printing floating point error

### DIFF
--- a/main.js
+++ b/main.js
@@ -330,9 +330,8 @@ function format(number, decPlaces = 2) {
     // We compare against an epsilon here because for very large numbers
     // (> 999D) floating point imprecision makes a direct comparison against 1 impractical
     if (Math.abs(number - Math.pow(10, Math.round(Math.log10(number)))) <= 1e-7)
-        return `${number.toFixed(0)}${abbrev[suffixIdx]}`;
-    else
-        return `${number.toFixed(decPlaces)}${abbrev[suffixIdx]}`;
+        decPlaces = 0;
+    return `${number.toFixed(decPlaces)}${abbrev[suffixIdx]}`;
 }
 
 var updateId = setInterval(() => {

--- a/main.js
+++ b/main.js
@@ -317,8 +317,8 @@ function format(number, decPlaces = 2) {
     // Abbreviations to enumerate over
     const abbrev = ["", "K", "M", "B", "T", "q", "Q", "s", "S", "O", "N", "D"];
     let exponent = Math.max(0, Math.log10(number));
-    let suffixIdx = Math.floor(exponent / 3);
-    number = number / Math.pow(10, Math.floor(exponent / 3) * 3);
+    let suffixIdx = Math.min(abbrev.length - 1, Math.floor(exponent / 3));
+    number = number / Math.pow(10, suffixIdx * 3);
 
     // Handle special case where we round up to the next abbreviation
     if ((Math.round(number) === 1000) && (exponent / 3 < abbrev.length - 1)) {
@@ -327,8 +327,10 @@ function format(number, decPlaces = 2) {
     }
 
     // Return the string with a decimal place if decimal portion is nonzero
-    if (number == Math.floor(number))
-        return `${number}${abbrev[suffixIdx]}`;
+    // We compare against an epsilon here because for very large numbers
+    // (> 999D) floating point imprecision makes a direct comparison against 1 impractical
+    if (Math.abs(number - Math.pow(10, Math.round(Math.log10(number)))) <= 1e-7)
+        return `${number.toFixed(0)}${abbrev[suffixIdx]}`;
     else
         return `${number.toFixed(decPlaces)}${abbrev[suffixIdx]}`;
 }

--- a/main.js
+++ b/main.js
@@ -314,7 +314,6 @@ $("#battle").click(() => {
 });
 
 function format(number, decPlaces = 2) {
-    // Abbreviations to enumerate over
     const abbrev = ["", "K", "M", "B", "T", "q", "Q", "s", "S", "O", "N", "D"];
     let exponent = Math.max(0, Math.log10(number));
     let suffixIdx = Math.min(abbrev.length - 1, Math.floor(exponent / 3));
@@ -330,6 +329,11 @@ function format(number, decPlaces = 2) {
     if (Math.round(number * Math.pow(10, decPlaces)) / Math.pow(10, decPlaces) % 1 === 0)
         decPlaces = 0;
     return `${number.toFixed(decPlaces)}${abbrev[suffixIdx]}`;
+
+    // Trim zeros off the decimal portion of the number
+    if (decPlaces > 0)
+        result = result.replace(/0+$/, "");
+    return result;
 }
 
 var updateId = setInterval(() => {

--- a/main.js
+++ b/main.js
@@ -318,7 +318,7 @@ function format(number, decPlaces = 2) {
     const abbrev = ["", "K", "M", "B", "T", "q", "Q", "s", "S", "O", "N", "D"];
     let exponent = Math.max(0, Math.log10(number));
     let suffixIdx = Math.min(abbrev.length - 1, Math.floor(exponent / 3));
-    number = number / Math.pow(10, suffixIdx * 3);
+    number /= Math.pow(10, suffixIdx * 3);
 
     // Handle special case where we round up to the next abbreviation
     if ((Math.round(number) === 1000) && (exponent / 3 < abbrev.length - 1)) {
@@ -326,10 +326,8 @@ function format(number, decPlaces = 2) {
         ++suffixIdx;
     }
 
-    // Return the string with a decimal place if decimal portion is nonzero
-    // We compare against an epsilon here because for very large numbers
-    // (> 999D) floating point imprecision makes a direct comparison against 1 impractical
-    if (Math.abs(number - Math.pow(10, Math.round(Math.log10(number)))) <= 1e-7)
+    // Return the string without a decimal place if decimal portion is zero
+    if (Math.round(number * Math.pow(10, decPlaces)) / Math.pow(10, decPlaces) % 1 === 0)
         decPlaces = 0;
     return `${number.toFixed(decPlaces)}${abbrev[suffixIdx]}`;
 }

--- a/main.js
+++ b/main.js
@@ -314,39 +314,23 @@ $("#battle").click(() => {
 });
 
 function format(number, decPlaces = 2) {
-    // 2 decimal places => 100, 3 => 1000, etc
-    decPlaces = Math.pow(10, decPlaces);
+    // Abbreviations to enumerate over
+    const abbrev = ["", "K", "M", "B", "T", "q", "Q", "s", "S", "O", "N", "D"];
+    let exponent = Math.max(0, Math.log10(number));
+    let suffixIdx = Math.floor(exponent / 3);
+    number = number / Math.pow(10, Math.floor(exponent / 3) * 3);
 
-    // Enumerate number abbreviations
-    var abbrev = ["K", "M", "B", "T", "q", "Q", "s", "S", "O", "N", "D"];
-
-    // Go through the array backwards, so we do the largest first
-    for (var i = abbrev.length - 1; i >= 0; i--) {
-
-        // Convert array index to "1000", "1000000", etc
-        var size = Math.pow(10, (i + 1) * 3);
-
-        // If the number is bigger or equal do the abbreviation
-        if (size <= number) {
-            // Here, we multiply by decPlaces, round, and then divide by decPlaces.
-            // This gives us nice rounding to a particular decimal place.
-            number = Math.round(number * decPlaces / size) / decPlaces;
-
-            // Handle special case where we round up to the next abbreviation
-            if ((number == 1000) && (i < abbrev.length - 1)) {
-                number = 1;
-                i++;
-            }
-
-            // Add the letter for the abbreviation
-            number += abbrev[i];
-
-            // We are done... stop
-            break;
-        }
+    // Handle special case where we round up to the next abbreviation
+    if ((Math.round(number) === 1000) && (exponent / 3 < abbrev.length - 1)) {
+        number = 1;
+        ++suffixIdx;
     }
 
-    return number;
+    // Return the string with a decimal place if decimal portion is nonzero
+    if (number == Math.floor(number))
+        return `${number}${abbrev[suffixIdx]}`;
+    else
+        return `${number.toFixed(decPlaces)}${abbrev[suffixIdx]}`;
 }
 
 var updateId = setInterval(() => {


### PR DESCRIPTION
In essence, this PR achieves two things.

1. Enforces type consistency in main.js:format. The original function would return a String if the input was great enough to get rounded up to "1.00K," and a Number for smaller numbers.
2. Truncates floating point error using Number.prototype.toFixed(). In the original function, if the passed input was 0.30000000000000004, then 0.30000000000000004 would be returned. The new revision returns "0.30."

Please give it a code review at your leisure.